### PR TITLE
Slider move in a wrong path when changing slider angle

### DIFF
--- a/src/app/components/SideNav/Edit/joint-edit-panel/joint-edit-panel.component.html
+++ b/src/app/components/SideNav/Edit/joint-edit-panel/joint-edit-panel.component.html
@@ -88,12 +88,12 @@
               <label style="margin-right: 5px;">Angle</label>
               <input
                 type="number"
-                [value]="pendingAngle ?? getJointAngle2()"
+                [value]="pendingAngle ?? getSliderJointAngle()"
                 (input)="pendingAngle = $any($event.target).valueAsNumber"
                 (keydown.enter)="confirmJointAngle()"
                 [disabled]="getJointLockState()"
               />
-              <span class="xy-unit">deg</span>
+              <span class="xy-unit">{{ angleSuffix }}</span>
             </div>
           </div>
         </div>

--- a/src/app/components/SideNav/Edit/joint-edit-panel/joint-edit-panel.component.ts
+++ b/src/app/components/SideNav/Edit/joint-edit-panel/joint-edit-panel.component.ts
@@ -178,6 +178,7 @@ export class jointEditPanelComponent implements OnInit, OnDestroy{
     if (this.pendingAngle == null) return;
 
     this.setJointAngle(this.pendingAngle);
+    this.getMechanism().notifyChange();
     this.pendingAngle = undefined;
   }
 

--- a/src/app/services/kinematic-solver.service.ts
+++ b/src/app/services/kinematic-solver.service.ts
@@ -656,9 +656,10 @@ export class PositionSolverService {
     if (m > 1000 || m < -1000) { // when angle is 90 degrees, tan will be 1/0 = undefined
       m = Number.MAX_VALUE;
     }
+    
     const prevJointPosition: Coord =
       prevPositions[solveOrder.indexOf(solvePrerequisite.jointToSolve.id)];
-
+    
     const n = prevJointPosition.y - m * prevJointPosition.x;
     
     // get a, b, c values
@@ -668,7 +669,6 @@ export class PositionSolverService {
     // get discriminant
     const d = Math.pow(b, 2) - 4 * a * c;
     
-    console.log('value of disciminant: ', d);
 
     //if discriminant is too big or not a number (NaN), use alternative method. We will see this case when angle of slider = 90 degrees
     if (isNaN(d) || !isFinite(d)) {
@@ -698,7 +698,7 @@ export class PositionSolverService {
       }
       x = prevJointPosition.x;
     } else { //if discriminant is normal, calculate intersection points and return closest.
-      if (d >= 0) {
+      if (d >= 0) { // discriminant d >= 0, there is at least 1 solution and at most 2 solutions
         const x_1 = (-b + Math.sqrt(Math.pow(b, 2) - 4 * a * c)) / (2 * a);
         const y_1 = m * x_1 + n;
         const x_2 = (-b - Math.sqrt(Math.pow(b, 2) - 4 * a * c)) / (2 * a);
@@ -716,12 +716,15 @@ export class PositionSolverService {
           Math.pow(x_2 - prevJointPosition.x, 2) +
             Math.pow(y_2 - prevJointPosition.y, 2)
         );
-        if (intersection1Diff < intersection2Diff) {
+        if (intersection1Diff < intersection2Diff) { // (x1,y1) closer to the last slider's position 
           x = intersectionPoints[0].x;
           y = intersectionPoints[0].y;
+        } else { // (x2,y2) closer to the last slider's position
+          x = intersectionPoints[1].x;
+          y = intersectionPoints[1].y;
         }
-      } else {
-        console.log('something weird happens to calculation logic with solveCircleLine() in kinematic-solver.service.ts')
+      } else { // discriminant < 0, there is no solution and it's also the signal about limit of the movement of the crank and we need to swap direction.
+        console.log('crank hits its limit and ready to change direction');
         return undefined;
       }
     }

--- a/src/app/services/kinematic-solver.service.ts
+++ b/src/app/services/kinematic-solver.service.ts
@@ -652,7 +652,8 @@ export class PositionSolverService {
       nextPositions[solveOrder.indexOf(solvePrerequisite.knownJointOne!.id)!].y;
 
     let m = Math.tan((solvePrerequisite.jointToSolve!.angle * Math.PI) / 180);
-    if (m > 1000 || m < -1000) {
+    
+    if (m > 1000 || m < -1000) { // when angle is 90 degrees, tan will be 1/0 = undefined
       m = Number.MAX_VALUE;
     }
     const prevJointPosition: Coord =
@@ -666,18 +667,17 @@ export class PositionSolverService {
     const c = Math.pow(h, 2) + Math.pow(n - k, 2) - Math.pow(r, 2);
     // get discriminant
     const d = Math.pow(b, 2) - 4 * a * c;
+    
+    console.log('value of disciminant: ', d);
 
-    //if discriminant is too big or not a number, use alternative method
+    //if discriminant is too big or not a number (NaN), use alternative method. We will see this case when angle of slider = 90 degrees
     if (isNaN(d) || !isFinite(d)) {
-      let temp_a: number = 1;
-      let temp_b: number = -2 * solvePrerequisite.knownJointOne!._coords.y;
-      let temp_c: number =
-        Math.pow(solvePrerequisite.knownJointOne!._coords.y, 2) +
-        Math.pow(
-          solvePrerequisite.knownJointOne!._coords.x - prevJointPosition.x,
-          2
-        ) -
-        Math.pow(r, 2);
+      // Line (vertical slider): x = t
+      // Circle: (x - h)^2 + (y - k)^2 = r^2
+      const t = prevJointPosition.x;
+      const temp_a: number = 1;
+      const temp_b: number = -2 * k;
+      const temp_c: number = Math.pow(k, 2) + Math.pow(t-h,2) - Math.pow(r, 2);
       let temp_d: number = Math.pow(temp_b, 2) - 4 * temp_a * temp_c;
       if (temp_d < 0) {
         return undefined;
@@ -697,8 +697,7 @@ export class PositionSolverService {
         y = y_2;
       }
       x = prevJointPosition.x;
-      //if discriminant is normal, calculate intersection points and return closest.
-    } else {
+    } else { //if discriminant is normal, calculate intersection points and return closest.
       if (d >= 0) {
         const x_1 = (-b + Math.sqrt(Math.pow(b, 2) - 4 * a * c)) / (2 * a);
         const y_1 = m * x_1 + n;
@@ -722,6 +721,7 @@ export class PositionSolverService {
           y = intersectionPoints[0].y;
         }
       } else {
+        console.log('something weird happens to calculation logic with solveCircleLine() in kinematic-solver.service.ts')
         return undefined;
       }
     }

--- a/src/app/services/kinematic-solver.service.ts
+++ b/src/app/services/kinematic-solver.service.ts
@@ -657,10 +657,9 @@ export class PositionSolverService {
     }
     const prevJointPosition: Coord =
       prevPositions[solveOrder.indexOf(solvePrerequisite.jointToSolve.id)];
-    const n =
-      solvePrerequisite.jointToSolve!.coords.y -
-      m *
-        prevPositions[solveOrder.indexOf(solvePrerequisite.jointToSolve.id)].x;
+
+    const n = prevJointPosition.y - m * prevJointPosition.x;
+    
     // get a, b, c values
     const a = 1 + Math.pow(m, 2);
     const b = -h * 2 + m * (n - k) * 2;

--- a/src/app/services/svg-path.service.ts
+++ b/src/app/services/svg-path.service.ts
@@ -29,13 +29,6 @@ export class SVGPathService {
       return '';
     }
 
-    //check if coordinates are collinear. If they are, use the two returned coords(the end points) to draw a line
-    const collinearCoords: Coord[] | undefined = this.findCollinearCoords(allCoords);
-    if (collinearCoords !== undefined) {
-
-      return this.calculateTwoPointPath(collinearCoords[0], collinearCoords[1], radius);
-    }
-
     let pathData = `M ${allCoords[0].x},${allCoords[0].y} `;
     for (let i = 1; i < allCoords.length; i++) {
       const currentCoord = allCoords[i];
@@ -84,7 +77,6 @@ export class SVGPathService {
         return undefined;
       }
     }
-
     // If all coords have the same slope with the 'start' point, they are collinear
     return [start, end];
   }


### PR DESCRIPTION


This PR fixes 
1/ A bug where the slider moves in a weird path when users change the angle of the slider joint. Also, it allows users to enter either degrees or radians values based on the current setting. 

2/ Fix error that slider cannot move at some positions.

3/ The slider's blue path drew incorrectly as a "double line."

What I fixed:

Fixes #285 
Corrected the calculation of slope for the linear equation of the slider line in kinematic-solver.service.ts.
Updated the confirmJointAngle() in joint-edit-panel.component.ts, so it could return the correct value in degrees/radians and also signal the change to stateService when users change the angle of the slider joint.

Fixes #287 
The kinematic solver was previously taking the wrong solution from the quadratic equation. The logic is now corrected to choose the solution (x1 or x2) that is physically closest to the slider's previous position, ensuring continuous motion.

Fixes #289 
Removes a faulty optimization that incorrectly reused a linkage-drawing function for the slider's path. This was causing the visual "double loop" line. The path is now correctly drawn by connecting all of its sequential points.