### PR TITLE
Fix: Stop trackpad pinch-zoom from scaling the whole page

### DIFF
--- a/src/app/services/pan-zoom.service.ts
+++ b/src/app/services/pan-zoom.service.ts
@@ -35,7 +35,9 @@ constructor() {
 
 }
   // Handles zooming in or out based on mouse scroll events and updates the viewBox accordingly.
+  // Note: "mouse-wheel-event" will be automatically transferred to "pinch-event" by the browser if we use touchpad on laptop
   public _onMouseScrollWheel(event: WheelEvent){
+      event.preventDefault(); // This tell the browser to stop using its default zoom function and use our zoom function code below instead
       event.stopPropagation();
 
       let zoomDirection: number = event.deltaY;


### PR DESCRIPTION
fixes #290 

The _onMouseScrollWheel() method was missing event.preventDefault(). This allowed the browser's native page zoom to trigger after our internal zoom logic, scaling the entire UI.

This commit adds event.preventDefault() to stop the browser's default behavior and ensure only the SVG grid is zoomed.