### PR TITLE
fixed joint locking interaction

### DIFF
--- a/src/app/model/mechanism.ts
+++ b/src/app/model/mechanism.ts
@@ -229,7 +229,7 @@ export class Mechanism {
       console.error(`Joint with ID ${jointID} ${errorMsg}`);
       return false;
     }
-    if (joint.locked && successMsg !== 'unwelded') {
+    if (joint.locked && successMsg !== 'unwelded' && successMsg !== 'has had a new link added') {
       console.error(`Joint with ID ${jointID} is locked`);
       return false;
     }


### PR DESCRIPTION
Previously when locking a link, you would be unable to add another link to the joint of the locked link. This fixes that interaction and allows it.